### PR TITLE
Fix Falcon v2.0 compliance

### DIFF
--- a/falcon_require_https/middleware.py
+++ b/falcon_require_https/middleware.py
@@ -25,7 +25,9 @@ class RequireHTTPS(object):
     """
 
     def process_request(self, req, resp):
-        if req.protocol.lower() == 'https':
+        # NOTE: replaced deprecated req.protocol
+        #       with req.scheme since it removed in Falcon v2.0.
+        if req.scheme.lower() == 'https':
             return
 
         xfp = req.get_header('X-FORWARDED-PROTO')

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -11,7 +11,7 @@ _TEST_PATH = '/https'
 @pytest.fixture()
 def simulate():
     app = falcon.API(middleware=[RequireHTTPS()])
-    app.add_route(_TEST_PATH, testing.TestResource())
+    app.add_route(_TEST_PATH, testing.SimpleTestResource())
 
     def simulate(protocol, headers=None):
         env = testing.create_environ(


### PR DESCRIPTION
Replace deprecated req.protocol attribute with req.scheme as it was removed in Falcon 2.0